### PR TITLE
Improve perfomance and fix some errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/dradtke/distchan"
+	"github.com/covrom/distchan"
 )
 
 func main() {

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ import (
 	"net"
 	"strings"
 
-	"github.com/dradtke/distchan"
+	"github.com/covrom/distchan"
 )
 
 func main() {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # distchan
 
 Package distchan enables Go channels to be used for distributed computation.
+Improved stable version by covrom.
 
 ## Why?
 

--- a/distchan.go
+++ b/distchan.go
@@ -165,9 +165,13 @@ func (s *Server) handleIncomingMessages(conn clientConn) {
 	var (
 		buf  = getBuffer()
 		dec  = gob.NewDecoder(&buf)
-		et   = reflect.TypeOf(s.inv).Elem()
+		et   reflect.Type
 		done = make(chan struct{})
 	)
+
+	if s.inv != nil {
+		et = reflect.TypeOf(s.inv).Elem()
+	}
 
 	defer close(done)
 

--- a/example/adder/client.go
+++ b/example/adder/client.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/dradtke/distchan"
+	"github.com/covrom/distchan"
 )
 
 type AdderInput struct {
@@ -40,7 +40,8 @@ func main() {
 		panic(err)
 	}
 
-	distchan.NewClient(conn, out, in).Start()
+	cli, _ := distchan.NewClient(conn, out, in)
+	cli.Start()
 
 	fmt.Println("waiting for input...")
 	for input := range in {

--- a/example/adder/server/server.go
+++ b/example/adder/server/server.go
@@ -11,7 +11,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/dradtke/distchan"
+	"github.com/covrom/distchan"
 )
 
 type AdderInput struct {
@@ -69,7 +69,7 @@ func main() {
 		panic(err)
 	}
 
-	server := distchan.NewServer(ln, out, in)
+	server,_ := distchan.NewServer(ln, out, in)
 	server.Start()
 
 	fmt.Println("waiting for clients to connect...")

--- a/example/capitalizer/client.go
+++ b/example/capitalizer/client.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"strings"
 
-	"github.com/dradtke/distchan"
+	"github.com/covrom/distchan"
 )
 
 func main() {
@@ -19,7 +19,8 @@ func main() {
 		in  = make(chan string)
 	)
 
-	client := distchan.NewClient(conn, out, in).Start()
+	client,_ := distchan.NewClient(conn, out, in)
+	client.Start()
 
 	// Loop over all input from the server...
 	for input := range in {

--- a/example/capitalizer/server/server.go
+++ b/example/capitalizer/server/server.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/dradtke/distchan"
+	"github.com/covrom/distchan"
 )
 
 func main() {
@@ -16,7 +16,7 @@ func main() {
 	var (
 		out    = make(chan string)
 		in     = make(chan string)
-		server = distchan.NewServer(ln, out, in)
+		server,_ = distchan.NewServer(ln, out, in)
 	)
 
 	server.Start()


### PR DESCRIPTION
Changes:
* switch from mutex to channels pipeline (fix race condition)
* use sync.Pool to manage buffers
* fix some errors (for example race condition between locking mutex)
* encoders and decoders API switch to io.Readers (memory reusage, idiomatic)
* reflect values lives short time (fix unsafe pointer leaks)
* add signature to message (fix memory leaks when receive incorrect protocol on connect unknown client)